### PR TITLE
Ett test misslyckades pga hårdkodat datum, ändrade till att dagens da…

### DIFF
--- a/trailrunner/src/test/java/se/iths/MainMenuTest.java
+++ b/trailrunner/src/test/java/se/iths/MainMenuTest.java
@@ -111,7 +111,7 @@ public class MainMenuTest {
     public void ifEnteredDateEmptyReturnTodaysDate() {
         when(mockScanner.nextLine()).thenReturn("");
 
-        LocalDate expected = LocalDate.of(2024, 1, 15);
+        LocalDate expected = LocalDate.now();
         LocalDate actual = mainMenu.createLocalDate(mainMenu.saveEnteredDate());
         
         assertEquals(expected, actual);


### PR DESCRIPTION
…tum används istället